### PR TITLE
ci: Don't rely on project's own knope.toml when testing old versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
           version: 0.16.2
       - name: Test Knope
         run: knope --help
+        working-directory: /tmp
       - name: Verify no artifacts in path
         run: git status
   pass-a-token:


### PR DESCRIPTION
We're using features that are too new / don't validate 😬